### PR TITLE
Add a padding to the document-excerpt span

### DIFF
--- a/src/static/scss/components/_document-excerpt.scss
+++ b/src/static/scss/components/_document-excerpt.scss
@@ -3,18 +3,20 @@
 
   &.-supressed {
     & * {
-      color: #ccc;
+      color: #CCC;
     }
   }
 }
 
 .document-excerpt {
+  padding: .25em 0;
   &.-enabled {
     user-select: text;
+
     color: #000;
   }
 
   .highlighted {
-    background-color: rgba(255, 255, 0, 0.3);
+    background-color: rgba(255, 255, 0, .3);
   }
 }


### PR DESCRIPTION
This supposedly might fix the issue that users are having when selecting text, especially on mobile. The space between lines today is unselectable, and now with this padding this won't happen anymore.