### PR TITLE
Replace buttons markup with actual <button> instead of <a>

### DIFF
--- a/src/static/scss/components/_opinion-card.scss
+++ b/src/static/scss/components/_opinion-card.scss
@@ -243,7 +243,7 @@
       margin-top: 2rem;
     }
 
-    & > a {
+    & > button {
       animation: show-opinion-button .3s $swift-out forwards;
       pointer-events: none; // This is set back to auto inside the show-opinion-button
 

--- a/src/templates/components/opinion-modal.html
+++ b/src/templates/components/opinion-modal.html
@@ -48,11 +48,11 @@
 
       <footer class="actions">
         {% if request.user.is_authenticated %}
-        <a href="#" class="disagree js-opinionButton" data-opinion="reject" aria-label="Discordo"></a>
-        <a href="#" class="indifferent js-opinionButton" data-opinion="neutral" aria-label="Indiferente"></a>
-        <a href="#" class="agree js-opinionButton" data-opinion="approve" aria-label="Concordo"></a>
+        <button class="disagree js-opinionButton" data-opinion="reject" aria-label="Discordo"></button>
+        <button class="indifferent js-opinionButton" data-opinion="neutral" aria-label="Indiferente"></button>
+        <button class="agree js-opinionButton" data-opinion="approve" aria-label="Concordo"></button>
         {% endif %}
-        <a href="#" class="skip js-nextOpinion" data-opinion="skip" aria-label="Pular Opinião"></a>
+        <button class="skip js-nextOpinion" data-opinion="skip" aria-label="Pular Opinião"></button>
       </footer>
     </article>
   {% endfor %}


### PR DESCRIPTION
Since an <a> needs an href attribute, we needed to use a placeholder on it, by default: "#".
This was causing the side effect of the page scrolling back to the top whenever you clicked on a vote button.
Also, a <button> is definitely the better semantic option in this case.