### PR TITLE
Fix opening all opinions through the appropriate button in the document

### DIFF
--- a/src/static/js/components/body/view.js
+++ b/src/static/js/components/body/view.js
@@ -16,7 +16,7 @@ BodyView.prototype.publishers = function() {
     var suggestionInput = target.closest('.js-suggestionInput');
     var opinionModal = target.closest('.js-opinionModal');
 
-    if (!target.hasClass('js-overlay') && target.closest('.js-opinionButton').length === 0) {
+    if (!target.hasClass('js-overlay') && target.closest('.js-opinionButton, .js-allOpinionsButton').length === 0) {
       if (suggestionInput.length === 0 && opinionModal.length === 0) {
         var selectedText = window.getSelection().toString();
         if (selectedText === '' || selectedText === self.previousSelectedText) {

--- a/src/static/js/components/documentExcerpt/view.js
+++ b/src/static/js/components/documentExcerpt/view.js
@@ -4,7 +4,7 @@ var DocumentExcerptView = function() {};
 
 DocumentExcerptView.prototype.initEvents = function() {
   this.documentBodyElement = $('.js-documentBody');
-  this.allOpinionsButton = $('.js-allOpinionsButton')
+  this.allOpinionsButton = $('.js-allOpinionsButton');
   this.showOpinionsButtons = $('.js-opinionButton, .js-allOpinionsButton');
   this.selectedHTML = undefined;
   this.lastExcerpt = undefined;
@@ -51,14 +51,15 @@ DocumentExcerptView.prototype.publishers = function() {
 
   self.showOpinionsButtons.click(function() {
     var opinionButton = $(this);
+    var excerptId = null;
 
     if (opinionButton.is('.js-allOpinionsButton')) {
-      var excerptId = 'all';
+      excerptId = 'all';
     } else {
-      var excerptId = opinionButton.closest('.js-excerptWrapper').find('.js-documentExcerpt').data('id');
+      excerptId = opinionButton.closest('.js-excerptWrapper').find('.js-documentExcerpt').data('id');
     }
 
-    events.openOpinionModal.publish(excerptId)
+    events.openOpinionModal.publish(excerptId);
   });
 };
 
@@ -120,5 +121,5 @@ DocumentExcerptView.prototype.hideExcerptOpinionBalloon = function(excerptId) {
 };
 
 DocumentExcerptView.prototype.hideDocumentOpinionBalloon = function(allOpinionsButton) {
-  allOpinionsButton.addClass('_hide')
+  allOpinionsButton.addClass('_hide');
 };

--- a/src/static/js/components/documentExcerpt/view.js
+++ b/src/static/js/components/documentExcerpt/view.js
@@ -4,6 +4,8 @@ var DocumentExcerptView = function() {};
 
 DocumentExcerptView.prototype.initEvents = function() {
   this.documentBodyElement = $('.js-documentBody');
+  this.allOpinionsButton = $('.js-allOpinionsButton')
+  this.showOpinionsButtons = $('.js-opinionButton, .js-allOpinionsButton');
   this.selectedHTML = undefined;
   this.lastExcerpt = undefined;
   this.selectedText = '';
@@ -11,6 +13,7 @@ DocumentExcerptView.prototype.initEvents = function() {
   this.publishers();
   this.subscribers();
 };
+
 
 DocumentExcerptView.prototype.publishers = function() {
   var self = this;
@@ -46,8 +49,16 @@ DocumentExcerptView.prototype.publishers = function() {
     });
   });
 
-  $('.js-opinionButton').on('click', function(e) {
-    events.openOpinionModal.publish($(e.target).closest('.js-excerptWrapper').find('.js-documentExcerpt').data('id'));
+  self.showOpinionsButtons.click(function() {
+    var opinionButton = $(this);
+
+    if (opinionButton.is('.js-allOpinionsButton')) {
+      var excerptId = 'all';
+    } else {
+      var excerptId = opinionButton.closest('.js-excerptWrapper').find('.js-documentExcerpt').data('id');
+    }
+
+    events.openOpinionModal.publish(excerptId)
   });
 };
 
@@ -72,7 +83,7 @@ DocumentExcerptView.prototype.subscribers = function() {
   });
 
   events.hideDocumentOpinionBalloon.subscribe(function() {
-    self.hideDocumentOpinionBalloon();
+    self.hideDocumentOpinionBalloon(self.allOpinionsButton);
   });
 
   events.suggestionUndone.subscribe(function(data) {
@@ -108,6 +119,6 @@ DocumentExcerptView.prototype.hideExcerptOpinionBalloon = function(excerptId) {
   balloon.addClass('_hide');
 };
 
-DocumentExcerptView.prototype.hideDocumentOpinionBalloon = function() {
-  $('.js-documentHeader').children('.js-opinionButton').addClass('_hide');
+DocumentExcerptView.prototype.hideDocumentOpinionBalloon = function(allOpinionsButton) {
+  allOpinionsButton.addClass('_hide')
 };

--- a/src/static/js/components/opinionModal/view.js
+++ b/src/static/js/components/opinionModal/view.js
@@ -152,7 +152,11 @@ OpinionModalView.prototype.opinionSent = function(opinion) {
 
 OpinionModalView.prototype.activateOpinionCards = function(excerptId) {
   var self = this;
-  if (excerptId) {
+  if (excerptId === 'all') {
+    self.cardsElements.removeClass('-inactive');
+    self.cardsElements.addClass('-active');
+    
+  } else {
     self.cardsElements.removeClass('-active');
     self.cardsElements.addClass('-inactive');
     self.modalContentElement.find('[data-excerpt-id="' + excerptId + '"]')

--- a/src/templates/pages/document.html
+++ b/src/templates/pages/document.html
@@ -48,7 +48,7 @@
         {% group_suggestions object as has_suggestions %}
       {% endif %}
       {% if has_suggestions %}
-      <button class="suggestion-opinion -all js-opinionButton" aria-label="Ver todas as opiniões"></button>
+      <button class="suggestion-opinion -all js-allOpinionsButton" aria-label="Ver todas as opiniões"></button>
       {% endif %}
     </header>
     {% for excerpt in object.document.excerpts.all %}


### PR DESCRIPTION
If you opened the opinion-modal through any of the excerpt buttons, and then tried to open again now through the project button, the -active/-inactive classes of the opinion-cards would retain their previous values from the last action.