### PR TITLE
Completely refactor the hovering-label reusable

### DIFF
--- a/src/static/img/triangle-pip-bottom.svg
+++ b/src/static/img/triangle-pip-bottom.svg
@@ -1,0 +1,3 @@
+<svg width="12" height="7" viewBox="0 0 12 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 6.5L0 0.499999L12 0.5L6 6.5Z" fill="#474747"/>
+</svg>

--- a/src/static/img/triangle-pip-right.svg
+++ b/src/static/img/triangle-pip-right.svg
@@ -1,0 +1,3 @@
+<svg width="6" height="13" viewBox="0 0 6 13" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6 6.5L0 12.5L0 0.5L6 6.5Z" fill="#474747"/>
+</svg>

--- a/src/static/scss/base/_reusables.scss
+++ b/src/static/scss/base/_reusables.scss
@@ -118,7 +118,7 @@
 }
 
 // Floating label for elements with content based of aria-label attributes. Available on :hover
-@mixin hovering-label($direction, $margin: .5em, $color:inherit, $font-size: 1em, $width: auto, $precedence: after, $button-position:relative) {
+@mixin hovering-label($direction, $style: 'default', $margin: .5em, $color:inherit, $font-size: 1em, $width: auto, $edge-boundary: 'default', $button-position: relative) {
   position: $button-position;
 
   @include bp-mediumup {
@@ -129,12 +129,83 @@
       @if $direction == 'right' or $direction == 'left' {
         transform: translate(0, -50%);
       } @else if $direction == 'top' or $direction == 'bottom' {
-        transform: translate(-50%, 0);
+        @if $edge-boundary == 'left' {
+          transform: translate(50%, 0);
+        } @else {
+          transform: translate(-50%, 0);
+        }
       }
     }
   }
 
-  &::#{$precedence} {
+  @if $style == 'tip-shortcut' {
+    &:hover::after {
+      transition: transform .3s .5s $swift-out, opacity .3s .5s $swift-out;
+    }
+
+    &:hover::before {
+      transition: transform .2s .6s $swift-out, opacity .2s .6s $swift-out;
+
+      opacity: 1;
+      @if $direction == 'right' {
+        transform: scaleX(-1) translate(0);
+      } @else if $direction == 'bottom' {
+        transform: scaleY(-1) translate(0);
+      } @else {
+        transform: translate(0);
+      }
+    }
+  }
+
+  @if $style != 'nobg' {
+    &::before {
+      position: absolute;
+
+      content: '';
+
+      @if $style == 'tip-shortcut' {
+        transition: transform .2s 0s $swift-out, opacity .1s 0s $swift-out;
+
+        opacity: 0;
+        background-repeat: no-repeat;
+
+
+        @if $direction == 'left' or $direction == 'right' {
+          height: 100%;
+          padding-left: $margin;
+
+          background-image: url('../img/triangle-pip-right.svg');
+          background-position: -1px 50%;
+        } @else if $direction == 'top' or $direction == 'bottom' {
+          width: 100%;
+          padding-bottom: $margin;
+
+          background-image: url('../img/triangle-pip-bottom.svg');
+          background-position: 50% -1px;
+        }
+
+        @if $direction == 'right' {
+          left: 100%;
+
+          transform: scaleX(-1) translateX(-100%);
+        } @else if $direction == 'left' {
+          right: 100%;
+
+          transform: translateX(-1em);
+        } @else if $direction == 'top' {
+          bottom: 100%;
+
+          transform: translateY(-1em);
+        } @else if $direction == 'bottom' {
+          top: 100%;
+
+          transform: scaleY(-1) translateY(-100%);
+        }
+      }
+    }
+  }
+
+  &::after {
     font-size: $font-size;
     font-weight: 600;
     line-height: 1;
@@ -145,46 +216,96 @@
     padding: .5em;
 
     content: attr(aria-label);
-    transition: transform .3s $swift-out, opacity .3s $swift-out;
+    transition: transform .3s 0s $swift-out, opacity .3s 0s $swift-out;
     white-space: nowrap;
     text-transform: uppercase;
     pointer-events: none;
 
     opacity: 0;
-    color: $color;
+    border-radius: 3px;
 
     @if $width != 'auto' {
-      white-space: pre-wrap;
+      white-space: pre-line;
     }
 
     @if $direction == 'right' {
       top: 50%;
       left: 100%;
 
-      padding-left: $margin;
-
       transform: translate(1em, -50%);
     } @else if $direction == 'left' {
       top: 50%;
       right: 100%;
-
-      padding-right: $margin;
 
       transform: translate(-1em, -50%);
     } @else if $direction == 'top' {
       bottom: 100%;
       left: 50%;
 
-      padding-bottom: $margin;
-
       transform: translate(-50%, 1em);
     } @else if $direction == 'bottom' {
       top: 100%;
       left: 50%;
 
-      padding-top: $margin;
-
       transform: translate(-50%, 1em);
+
+      @if $edge-boundary == 'right' {
+        right: unset;
+        left: -1rem;
+      } @else if $edge-boundary == 'left' {
+        right: -1rem;
+        left: unset;
+
+        transform: translate(50%, 1em);
+      }
+    }
+
+    @if $style == 'default' {
+      padding: .75em 1em;
+
+      color: $color-whitesmoke;
+      background: $color-deep-gray;
+    }
+
+    @if $style != 'nobg' {
+      @if $direction == 'right' {
+        margin-left: $margin;
+      } @else if $direction == 'left' {
+        margin-right: $margin;
+      } @else if $direction == 'top' {
+        margin-bottom: $margin;
+      } @else if $direction == 'bottom' {
+        margin-top: $margin;
+      }
+    }
+
+    @if $style == 'nobg' {
+      color: $color;
+      background-color: transparent;
+
+      @if $direction == 'right' {
+        padding-left: $margin;
+      } @else if $direction == 'left' {
+        padding-right: $margin;
+      } @else if $direction == 'top' {
+        padding-bottom: $margin;
+      } @else if $direction == 'bottom' {
+        padding-top: $margin;
+      }
+    }
+
+    @if $style == 'tip-shortcut' {
+      font-size: $font-size-micro;
+      font-weight: 400;
+
+      padding: .5rem;
+
+      content: attr(aria-label) '\2002\2003' attr(aria-keyshortcuts);
+      transition: transform .3s 0s $swift-out, opacity .3s 0s $swift-out;
+      text-transform: unset;
+
+      color: #FFF;
+      background-color: $color-deep-gray;
     }
   }
 }

--- a/src/static/scss/components/_document-card.scss
+++ b/src/static/scss/components/_document-card.scss
@@ -90,7 +90,7 @@
       transition: transform .3s $swift-out;
 
       @include icon('add-gray', 4rem, 4rem);
-      @include hovering-label(bottom, .5em, $color-grayish);
+      @include hovering-label(bottom, 'nobg', .5em, $color-grayish);
     }
   }
 

--- a/src/static/scss/components/_document-editor.scss
+++ b/src/static/scss/components/_document-editor.scss
@@ -262,7 +262,7 @@ body.-analysis {
 
     border-radius: .25rem;
 
-    @include hovering-label(left, 0, inherit, $font-size-micro, auto, after, absolute);
+    @include hovering-label(left, 'tip-shortcut', .75rem, inherit, $font-size-micro, auto, 'default', absolute);
 
     &::after {
       font-size: $font-size-micro;

--- a/src/static/scss/components/_nav-bar.scss
+++ b/src/static/scss/components/_nav-bar.scss
@@ -209,20 +209,11 @@ body.-white .nav-bar {
 
   & > .tools > a,
   & > .tools > .dropdown-menu.-notifications > .icon {
-    @include hovering-label(bottom, 2em, $color-whitesmoke, .875rem);
+    @include hovering-label(bottom, 'default', 1rem, $color-whitesmoke, .875rem);
   }
 
-  & > .tools > .icon::after,
-  & > .tools > .dropdown-menu.-notifications > .icon::after {
-    margin-top: .5em;
-    padding: .75em 1em;
-
-    border-radius: .25rem;
-    background-color: $color-deep-gray;
-  }
-
-  & > .tools > .icon.-documents::after {
-    left: -1rem;
+  & > .tools > .icon.-documents {
+    @include hovering-label(bottom, 'default', 1rem, $color-whitesmoke, .875rem, auto, 'right');
   }
 
   & > .tools > a.-active {

--- a/src/static/scss/components/_opinion-card.scss
+++ b/src/static/scss/components/_opinion-card.scss
@@ -276,7 +276,7 @@
       animation-delay: .7s;
 
       @include icon('disagree');
-      @include hovering-label(left, 1em, #FFF, 1rem);
+      @include hovering-label(left, 'nobg', 1em, #FFF, 1rem);
     }
 
     & > .indifferent {
@@ -288,7 +288,7 @@
 
       animation-delay: .8s;
 
-      @include hovering-label(bottom, 1em, #FFF, 1rem);
+      @include hovering-label(bottom, 'nobg', 1em, #FFF, 1rem);
       @include bp-mediumup {
         margin: 0 3rem;
       }
@@ -302,7 +302,7 @@
 
       animation-delay: .9s;
 
-      @include hovering-label(right, 1em, #FFF, 1rem);
+      @include hovering-label(right, 'nobg', 1em, #FFF, 1rem);
       @include icon('agree');
     }
 
@@ -318,7 +318,7 @@
       animation-delay: 1s;
 
       @include icon('skip');
-      @include hovering-label(left, 1em, #FFF, 1rem, auto, after, absolute);
+      @include hovering-label(left, 'nobg', 1em, #FFF, 1rem, auto, 'default', absolute);
     }
 
     & > .notice {

--- a/src/static/scss/components/_suggestion-opinion.scss
+++ b/src/static/scss/components/_suggestion-opinion.scss
@@ -16,7 +16,7 @@
 
   @include icon(comment, 17px, 18px);
   @include bp-mediumup {
-    @include hovering-label(right, 0, inherit, 1em, 6rem);
+    @include hovering-label(right, 'nobg', 0, inherit, 1em, 6rem);
   }
 
   &.-all {

--- a/src/static/scss/components/_tool-bar.scss
+++ b/src/static/scss/components/_tool-bar.scss
@@ -36,18 +36,11 @@
     width: 100%;
     height: 4.5rem;
 
-    @include hovering-label(left, 2em, $color-whitesmoke, .875rem);
+    @include hovering-label(left, 'default', 1rem, $color-whitesmoke, .875rem);
 
     &:hover > svg path {
       fill: $color-deep-gray;
     }
-  }
-
-  & > .tools > .icon::after {
-    background-color: $color-deep-gray;
-    padding: 0.75em 1em;
-    border-radius: 0.25rem;
-    margin-right: 1em;
   }
 
   & > .tools > .icon.-active > svg path {

--- a/src/static/scss/components/howto-button.scss
+++ b/src/static/scss/components/howto-button.scss
@@ -12,7 +12,7 @@
 
   box-shadow: none;
 
-  @include hovering-label(left, 1em, $color-gray, $font-size-micro, auto, after, fixed);
+  @include hovering-label(left, 'nobg', 1em, $color-gray, $font-size-micro, auto, 'default', fixed);
   @include bp-smallonly {
     font-size: .7rem;
 

--- a/src/templates/components/document-editor.html
+++ b/src/templates/components/document-editor.html
@@ -2,7 +2,7 @@
 
 <article class="js-textEditorWrapper">
 
-  <button class="modify js-openContextualToolbar" aria-label="Trocar articulação  |  Tab">
+  <button class="modify js-openContextualToolbar" aria-label="Trocar articulação" aria-keyshortcuts="TAB">
     <svg xmlns="http://www.w3.org/2000/svg" width="14" height="10" fill="#383838"><path d="M3.854.854a.5.5 0 1 0-.707-.707L.793 2.5l2.354 2.354a.5.5 0 0 0 .707-.707L2.707 3H12a.5.5 0 1 0 0-1H2.707L3.854.854zm6.293 5a.5.5 0 0 1 .707-.707L13.207 7.5l-2.354 2.354a.5.5 0 0 1-.707-.707L11.293 8H2a.5.5 0 1 1 0-1h9.293l-1.146-1.146z"/></svg>
   </button>
 


### PR DESCRIPTION
- Add a new "tip-shortcut" style that also reads "aria-keyshortcuts" properties and add them to the label
- Add a new default style that has a background for contrast
- Make the original default style into the "nobg" style
- Add a new "edge-boundary" parameter, that aligns the label to the left or right edge of the parent element (useful for elements near the horizontal edges of the screen)